### PR TITLE
Update mongodb dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "url": "https://github.com/watson/json2mongo/issues"
   },
   "dependencies": {
-    "mongodb": "^1.4.0"
+    "mongodb": "^2.2.11"
   }
 }


### PR DESCRIPTION
The native module building is failing in node 4/6 - this is due to bson/nan referencing old v8 stuff I imagine.

Latest version of mongodb (2.x) updates bson -- the latest version no longer does native compilations -- this seems to work properly now.