### PR TITLE
Add support for mongo.Decimal128

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (obj) {
       case '$date':
         return new Date(val)
       case '$decimal128':
-        return new mongo.Decimal128(Buffer.from(val))
+        return new mongo.Decimal128(new Buffer(val))
       case '$timestamp':
         return new mongo.Timestamp(val.t, val.i)
       case '$regex':

--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ module.exports = function (obj) {
         return new mongo.Binary(obj.$binary, obj.$type)
       case '$date':
         return new Date(val)
+      case '$decimal128':
+        return new mongo.Decimal128(Buffer.from(val))
       case '$timestamp':
         return new mongo.Timestamp(val.t, val.i)
       case '$regex':

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ var query = {
 var result = {
   _id: mongo.ObjectID(query._id.$oid),
   created: new Date('2013-01-01T00:00:00.000Z'),
-  decimal: new mongo.Decimal128(Buffer.from('42.42')),
+  decimal: new mongo.Decimal128(new Buffer('42.42')),
   ts: mongo.Timestamp(1412180887, 1),
   fkey1: new mongo.DBRef(query.fkey1.$ref, mongo.ObjectID(query.fkey1.$id.$oid), query.fkey1.$db),
   fkey2: new mongo.DBRef(query.fkey2.$ref, mongo.ObjectID(query.fkey2.$id.$oid)),

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ var json2mongo = require('./')
 var query = {
   _id: { $oid: '123456789012345678901234' },
   created: { $date: '2013-01-01T00:00:00.000Z' },
+  decimal: { $decimal128: '42.42' },
   ts: { $timestamp: { t: 1412180887, i: 1 } },
   fkey1: { $ref: 'creators', $id: { $oid: '123456789012345678901234' }, $db: 'users' },
   fkey2: { $ref: 'creators', $id: { $oid: '123456789012345678901234' } },
@@ -29,6 +30,7 @@ var query = {
 var result = {
   _id: mongo.ObjectID(query._id.$oid),
   created: new Date('2013-01-01T00:00:00.000Z'),
+  decimal: new mongo.Decimal128(new Buffer('42.42')),
   ts: mongo.Timestamp(1412180887, 1),
   fkey1: new mongo.DBRef(query.fkey1.$ref, mongo.ObjectID(query.fkey1.$id.$oid), query.fkey1.$db),
   fkey2: new mongo.DBRef(query.fkey2.$ref, mongo.ObjectID(query.fkey2.$id.$oid)),

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ var query = {
 var result = {
   _id: mongo.ObjectID(query._id.$oid),
   created: new Date('2013-01-01T00:00:00.000Z'),
-  decimal: new mongo.Decimal128(new Buffer('42.42')),
+  decimal: new mongo.Decimal128(Buffer.from('42.42')),
   ts: mongo.Timestamp(1412180887, 1),
   fkey1: new mongo.DBRef(query.fkey1.$ref, mongo.ObjectID(query.fkey1.$id.$oid), query.fkey1.$db),
   fkey2: new mongo.DBRef(query.fkey2.$ref, mongo.ObjectID(query.fkey2.$id.$oid)),


### PR DESCRIPTION
There was no ability to use Decimal128 before.
But we really need this one.